### PR TITLE
Fixed 'reason' string

### DIFF
--- a/src/main/java/es/hulk/survival/command/admin/BanCommand.java
+++ b/src/main/java/es/hulk/survival/command/admin/BanCommand.java
@@ -5,6 +5,7 @@ import es.hulk.survival.utils.command.Command;
 import es.hulk.survival.utils.command.CommandArgs;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
+import java.util.Arrays;
 
 import static org.bukkit.BanList.Type;
 
@@ -16,7 +17,9 @@ public class BanCommand extends BaseCommand {
     public void onCommand(CommandArgs command) {
         Player player = command.getPlayer();
         String[] args = command.getArgs();
-        String reason = args[1];
+        String reason = Arrays.toString(Arrays.copyOfRange(args, 0, args.length))
+                    .replaceAll(",", "")
+                    .replace("[", "").replace("]", "");
 
         Player target = Bukkit.getPlayer(args[0]);
         assert target != null;


### PR DESCRIPTION
The 'reason' string used to only show 1 word from the actual reason string
so for example, if the reason was 'he was hacking' the reason string would be 'he'
but now, it would all show up.